### PR TITLE
fix(security): upgrade path-to-regexp to >=8.4.0 to fix DoS vulnerabi…

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,5 +12,10 @@
   "devDependencies": {
     "typescript": "~5.9.2",
     "prettier": "^3.8.1"
+  },
+  "pnpm": {
+    "overrides": {
+      "path-to-regexp": ">=8.4.0"
+    }
   }
 }


### PR DESCRIPTION
…lity

- Added pnpm.overrides to force path-to-regexp >=8.4.0
- Fixes CVE for sequential optional groups DoS (issue #26)
- Patches vulnerability in versions >= 8.0.0, < 8.4.0