### PR TITLE
Fix: Silence DeepSource warning for admin password prompt

### DIFF
--- a/oh-my-guard/agent/install-agent.sh
+++ b/oh-my-guard/agent/install-agent.sh
@@ -21,9 +21,9 @@ read -rp "Oh-My-Guard! server URL [$AEGIS_SERVER]: " INPUT
 AEGIS_SERVER="${INPUT:-$AEGIS_SERVER}"
 
 read -rp "Admin username: " ADMIN_USER
+# skipcq: SCT-A000
 read -rsp "Admin password: " ADMIN_CRED; echo
 
-# skipcq: SCT-A000
 # ── Create directories ────────────────────────────────────────────────────────
 mkdir -p "$AGENT_DIR" "$CONF_DIR" "$LOG_DIR"
 chmod 750 "$CONF_DIR"


### PR DESCRIPTION
Moved `# skipcq: SCT-A000` pragma to properly apply to the `read` command for the admin password, resolving a DeepSource false-positive finding.

---
*PR created automatically by Jules for task [18206702560820741651](https://jules.google.com/task/18206702560820741651) started by @gux-htm*